### PR TITLE
feat: add todo command with markdown support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,23 @@ Now you can run:
 ```bash
 shady --name Nolan
 ```
+
+## Todos
+
+Create a todo item with a short text:
+
+```bash
+shady todo add "Buy milk"
+```
+
+Add a todo with additional Markdown content, edited in your `$EDITOR` (defaults to `vi`):
+
+```bash
+shady todo add "Plan meeting" --md
+```
+
+Show all saved todos:
+
+```bash
+shady todo list
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "A simple CLI for the shady project"
 authors = [{name = "Unknown"}]
 readme = "README.md"
 requires-python = ">=3.8"
-dependencies = ["typer>=0.9.0"]
+dependencies = ["typer>=0.9.0", "rich>=13.0.0"]
 
 [project.scripts]
 shady = "shady_cli.__main__:main"

--- a/shady_cli/__main__.py
+++ b/shady_cli/__main__.py
@@ -2,13 +2,12 @@
 
 import typer
 
+from .hello import hello
+from .todo import app as todo_app
+
 app = typer.Typer()
-
-
-@app.command()
-def hello(name: str = "world") -> None:
-    """Greet the given NAME."""
-    typer.echo(f"Hello {name}!")
+app.command()(hello)
+app.add_typer(todo_app, name="todo")
 
 
 def main() -> None:

--- a/shady_cli/hello.py
+++ b/shady_cli/hello.py
@@ -1,0 +1,8 @@
+"""Hello command for shady CLI."""
+
+import typer
+
+
+def hello(name: str = "world") -> None:
+    """Greet the given NAME."""
+    typer.echo(f"Hello {name}!")

--- a/shady_cli/todo.py
+++ b/shady_cli/todo.py
@@ -1,0 +1,52 @@
+"""Todo command group for shady CLI."""
+
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.markdown import Markdown
+
+app = typer.Typer()
+console = Console()
+TODO_FILE = Path.home() / ".shady_todos.json"
+
+
+def _load_todos() -> list:
+    if TODO_FILE.exists():
+        return json.loads(TODO_FILE.read_text())
+    return []
+
+
+def _save_todos(todos: list) -> None:
+    TODO_FILE.write_text(json.dumps(todos, indent=2))
+
+
+@app.command()
+def add(text: str, md: bool = typer.Option(False, "--md", help="Attach Markdown using vi")) -> None:
+    """Add a todo with TEXT. Optionally attach Markdown."""
+    markdown = ""
+    if md:
+        editor = os.environ.get("EDITOR", "vi")
+        with tempfile.NamedTemporaryFile(suffix=".md", delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+        subprocess.call([editor, str(tmp_path)])
+        markdown = tmp_path.read_text()
+        tmp_path.unlink()
+    todos = _load_todos()
+    todos.append({"text": text, "markdown": markdown})
+    _save_todos(todos)
+    typer.echo("Todo added")
+
+
+@app.command("list")
+def list_todos() -> None:
+    """List all todos."""
+    todos = _load_todos()
+    for idx, todo in enumerate(todos, 1):
+        typer.echo(f"{idx}. {todo['text']}")
+        if todo.get("markdown"):
+            console.print(Markdown(todo["markdown"]))


### PR DESCRIPTION
## Summary
- add `todo` command with optional Markdown attachment edited via user's editor
- render Markdown in console using rich and document usage
- split CLI commands into dedicated modules

## Testing
- `python -m shady_cli --help`
- `python -m shady_cli hello`
- `python -m shady_cli todo --help`
- `python -m shady_cli todo add "Another item"`
- `python -m shady_cli todo list`


------
https://chatgpt.com/codex/tasks/task_e_68b171ed20a8832ab902814a6291b55e